### PR TITLE
Guzzle update to version 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "GPL-2.0",
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "^5.3.1"
+        "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "2.*",

--- a/src/DivideIQ.php
+++ b/src/DivideIQ.php
@@ -209,6 +209,26 @@ class DivideIQ implements \JsonSerializable
     }
 
     /**
+     * Downloads a file using current client configuration and saves it at the specified destination.
+     *
+     * @param string|\Psr\Http\Message\UriInterface $uri File URI.
+     * @param string|resource|\Psr\Http\Message\StreamInterface $destination Destination where the file should be saved to.
+     */
+    public function download($uri, $destination)
+    {
+        // Setup the connection.
+        $this->setup();
+
+        $this->client->get($uri, [
+            'headers' => [
+                'Content-Type' => null,
+                'Authentication' => $this->accessToken->getToken(),
+            ],
+            'sink' => $destination,
+        ]);
+    }
+
+    /**
      * Serializes the object using JSON.
      *
      * @return string


### PR DESCRIPTION
Ported to Guzzle 6.
Additionally:
* Added an ability to override default HTTP client options
* Default request timeout set to 60 secs
* Added an ability to download files.